### PR TITLE
feat(auth): Refresh 회전 + 블랙리스트(DB) 적용

### DIFF
--- a/requests.http
+++ b/requests.http
@@ -1,0 +1,76 @@
+@baseUrl = http://localhost:8080
+@email = 1rkdalsgur1@naver.com
+@password = kmh0824!
+
+### 1) 로그인: Access는 헤더로, Refresh는 쿠키로 발급
+POST {{baseUrl}}/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "{{email}}",
+  "password": "{{password}}"
+}
+
+> {%
+    // 응답의 Authorization 헤더에서 Access 토큰을 뽑아 전역 변수로 저장
+    const auth = response.headers.valueOf('Authorization') || '';
+    if (auth.startsWith('Bearer ')) {
+        const access = auth.substring('Bearer '.length);
+        client.global.set('access', access);
+        client.log('Access set ✔');
+    } else {
+        client.log('Authorization header missing');
+    }
+%}
+
+### 2) 보호 API(me): Access 토큰으로 호출 (200 기대)
+GET {{baseUrl}}/api/auth/me
+Authorization: Bearer {{access}}
+
+> {%
+    client.test("me: 200 OK", () => {
+        client.assert(response.status === 200, "expected 200");
+    });
+%}
+
+### 3) 재발급(Refresh 쿠키 사용): 새 Access가 Authorization 헤더로 내려와야 함 (200 기대)
+POST {{baseUrl}}/api/auth/token/refresh
+
+> {%
+    const auth = response.headers.valueOf('Authorization') || '';
+    if (auth.startsWith('Bearer ')) {
+        client.global.set('access', auth.substring('Bearer '.length));
+        client.log('Access rotated ✔');
+    }
+    client.test("refresh: 200 OK", () => {
+        client.assert(response.status === 200 || response.status === 204, "expected 200/204");
+    });
+%}
+
+### 4) me(재발급 후): 새 Access로 다시 호출 (200 기대)
+GET {{baseUrl}}/api/auth/me
+Authorization: Bearer {{access}}
+
+> {%
+    client.test("me after refresh: 200 OK", () => {
+        client.assert(response.status === 200, "expected 200");
+    });
+%}
+
+### 5) 로그아웃: Refresh 삭제 쿠키 확인 (204 기대)
+POST {{baseUrl}}/api/auth/logout
+
+> {%
+    client.test("logout: 204 No Content", () => {
+        client.assert(response.status === 204, "expected 204");
+    });
+%}
+
+### 6) me(로그아웃 후): 토큰 없이 호출해 401이어야 정상 (401 기대)
+GET {{baseUrl}}/api/auth/me
+
+> {%
+    client.test("me without token: 401", () => {
+        client.assert(response.status === 401, "expected 401");
+    });
+%}

--- a/src/main/java/com/jobboard/jobportal/config/LocalDataLoader.java
+++ b/src/main/java/com/jobboard/jobportal/config/LocalDataLoader.java
@@ -1,0 +1,4 @@
+package com.jobboard.jobportal.config;
+
+public class LocalDataLoader {
+}

--- a/src/main/java/com/jobboard/jobportal/config/SecurityConfig.java
+++ b/src/main/java/com/jobboard/jobportal/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.jobboard.jobportal.config;
 
 import com.jobboard.jobportal.security.JwtAuthenticationFilter;
 import com.jobboard.jobportal.security.JwtUtil;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,37 +20,54 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @RequiredArgsConstructor
-@Profile({"prod", "stage", "test", "local"}) // 기본 로컬도 운영과 '동일 정책'으로 돌립니다.
+@Profile({"prod", "stage", "test", "local"}) // 운영/스테이지/테스트/로컬 공통 정책
 public class SecurityConfig {
 
-    // com.jobboard.jobportal.config.SecurityConfig (기존 파일 수정)
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtUtil jwtUtil) throws Exception {
         http
-                .cors(c -> {}) // WebConfig 기반
+                // CORS는 WebConfig(+프로퍼티)에서만 관리: 여기서는 활성화만
+                .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin(fl -> fl.disable())
                 .httpBasic(hb -> hb.disable())
+
                 .authorizeHttpRequests(auth -> auth
+                        // 프리플라이트 허용
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/auth/**").permitAll()
+                        // 인증 없이 접근 가능한 엔드포인트(POST 3개만!)
+                        .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/auth/logout").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/auth/token/refresh").permitAll()
+                        // 헬스체크 오픈
                         .requestMatchers("/actuator/health").permitAll()
+                        // 그 외는 인증 필요
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil),
-                        UsernamePasswordAuthenticationFilter.class);
+
+                // 미인증 → 401, 권한부족 → 403 일관화
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((req, res, e) ->
+                                res.sendError(HttpServletResponse.SC_UNAUTHORIZED))
+                        .accessDeniedHandler((req, res, e) ->
+                                res.sendError(HttpServletResponse.SC_FORBIDDEN))
+                );
+
+        // ★ Jwt 필터 연결 (반드시 exceptionHandling() 바깥에서 체인 계속)
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtUtil),
+                UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
 
-    // 이미 있는 경우 생략
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
     }
 
     @Bean
-    public PasswordEncoder passwordEncoder() { return new BCryptPasswordEncoder(); }
-
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 }

--- a/src/main/java/com/jobboard/jobportal/controller/AuthController.java
+++ b/src/main/java/com/jobboard/jobportal/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.jobboard.jobportal.controller;
 
 import com.jobboard.jobportal.repository.UserRepository;
 import com.jobboard.jobportal.security.JwtUtil;
+import com.jobboard.jobportal.service.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -9,8 +10,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.util.StringUtils;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
 
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -20,6 +27,8 @@ import jakarta.validation.constraints.Size;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import jakarta.servlet.http.HttpServletRequest;
+
 
 @RestController
 @RequestMapping("/api/auth")
@@ -29,6 +38,7 @@ public class AuthController {
     private final AuthenticationManager authManager;
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository; // me 응답 시 id 추출용(선택)
+    private final RefreshTokenService refreshTokenService; // ← 인터페이스 주입
 
     // ===== DTO =====
     public record LoginRequest(
@@ -40,43 +50,56 @@ public class AuthController {
 
     // ===== 로그인 =====
     @PostMapping("/login")
-    public ResponseEntity<UserSummary> login(@Valid @RequestBody LoginRequest req,
-                                             HttpServletResponse res) {
+    public ResponseEntity<?> login(@Valid @RequestBody LoginRequest req,
+                                   HttpServletRequest request,        // ← 이름: request
+                                   HttpServletResponse response) {    // ← 이름: response
+        try {
+            Authentication auth = authManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(req.email(), req.password())
+            );
 
-        Authentication auth = authManager.authenticate(
-                new UsernamePasswordAuthenticationToken(req.email(), req.password())
-        );
+            UserDetails principal = (UserDetails) auth.getPrincipal();
+            var roles = principal.getAuthorities().stream()
+                    .map(a -> a.getAuthority().replaceFirst("^ROLE_", ""))
+                    .toList();
 
-        UserDetails principal = (UserDetails) auth.getPrincipal();
+            String access  = jwtUtil.generateAccess(principal.getUsername(), roles);
+            String refresh = jwtUtil.generateRefresh(principal.getUsername());
 
-        // roles from authorities → ["USER","ADMIN", ...]
-        List<String> roles = principal.getAuthorities().stream()
-                .map(a -> a.getAuthority().replaceFirst("^ROLE_", ""))
-                .toList();
+            // 헤더/쿠키
+            response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + access);
+            ResponseCookie cookie = ResponseCookie.from("refreshToken", refresh)
+                    .httpOnly(true).secure(false).sameSite("Lax").path("/")
+                    .maxAge(Duration.ofDays(7)).build();
+            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-        String access  = jwtUtil.generateAccess(principal.getUsername(), roles);
-        String refresh = jwtUtil.generateRefresh(principal.getUsername());
+            // 🔹 DB 저장 (UA/IP 포함)
+            var user = userRepository.findByEmail(principal.getUsername()).orElseThrow();
+            refreshTokenService.saveLoginToken(
+                    user,
+                    refresh,
+                    request.getHeader("User-Agent"),   // ← getHeader 사용
+                    clientIp(request)                  // ← 아래 헬퍼 메서드
+            );
 
-        // Access → 헤더
-        res.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + access);
-
-        // Refresh → HttpOnly 쿠키 (로컬 정책: SameSite=Lax, Secure=false)
-        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refresh)
-                .httpOnly(true)
-                .secure(false)          // stage/prod 에서는 true + Domain=.jobportal.site (예시)
-                .sameSite("Lax")        // stage/prod 에서는 "None"
-                .path("/")
-                .maxAge(Duration.ofDays(7))
-                .build();
-        res.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
-
-        // id는 선택: 이메일로 조회해서 넣어줌
-        Long id = userRepository.findByEmail(principal.getUsername())
-                .map(u -> u.getId())
-                .orElse(null);
-
-        return ResponseEntity.ok(new UserSummary(id, principal.getUsername(), roles));
+            return ResponseEntity.ok(Map.of(
+                    "email", principal.getUsername(),
+                    "roles", roles
+            ));
+        } catch (AuthenticationException e) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "code", "AUTH_INVALID_CREDENTIALS",
+                    "message", "아이디 또는 비밀번호가 일치하지 않습니다."
+            ));
+        }
     }
+
+    private static String clientIp(HttpServletRequest req) {
+        String fwd = req.getHeader("X-Forwarded-For");
+        return (fwd != null && !fwd.isBlank()) ? fwd.split(",")[0].trim() : req.getRemoteAddr();
+    }
+
+
 
     // ===== 내 정보(보호) =====
     @GetMapping("/me")
@@ -106,4 +129,48 @@ public class AuthController {
         res.addHeader(HttpHeaders.SET_COOKIE, delete.toString());
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/token/refresh")
+    public ResponseEntity<Void> refresh(
+            @CookieValue(name = "refreshToken", required = false) String refresh,
+            HttpServletResponse res
+    ) {
+        // 1) 쿠키 없는 경우
+        if (!StringUtils.hasText(refresh)) {
+            return ResponseEntity.status(401).build();
+        }
+
+        try {
+            // 2) Refresh 파싱 및 검증
+            Jws<Claims> jws = jwtUtil.parse(refresh);
+            Claims c = jws.getBody();
+            if (!"refresh".equals(c.get("type"))) {
+                return ResponseEntity.status(401).build();
+            }
+
+            // 3) 주체(email) 기준 권한 조회(간단 버전)
+            String email = c.getSubject();
+            var roles = userRepository.findByEmail(email)
+                    .map(u -> java.util.List.of(u.getRole().name().replaceFirst("^ROLE_", "")))
+                    .orElse(java.util.List.of("USER"));
+
+            // 4) 새 Access 발급 → Authorization 헤더로 반환
+            String access = jwtUtil.generateAccess(email, roles);
+            res.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + access);
+
+            return ResponseEntity.noContent().build();
+        } catch (JwtException e) {
+            // (선택) 잘못된 쿠키는 즉시 삭제해 UX/보안 개선
+            ResponseCookie delete = ResponseCookie.from("refreshToken", "")
+                    .httpOnly(true)
+                    .secure(false)   // stage/prod에서는 true + Domain/SameSite=None
+                    .sameSite("Lax")
+                    .path("/")
+                    .maxAge(0)
+                    .build();
+            res.addHeader(HttpHeaders.SET_COOKIE, delete.toString());
+            return ResponseEntity.status(401).build();
+        }
+    }
+
 }

--- a/src/main/java/com/jobboard/jobportal/entity/RefreshToken.java
+++ b/src/main/java/com/jobboard/jobportal/entity/RefreshToken.java
@@ -1,0 +1,44 @@
+package com.jobboard.jobportal.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class RefreshToken {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "token_hash", length = 64, nullable = false, unique = true)
+    private String tokenHash;                 // SHA-256(hex)
+
+    @Column(name = "issued_at", nullable = false)
+    private LocalDateTime issuedAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "revoked_at")
+    private LocalDateTime revokedAt;
+
+    @OneToOne
+    @JoinColumn(name = "replaced_by_id")
+    private RefreshToken replacedBy;
+
+    @Column(name = "user_agent")
+    private String userAgent;
+
+    @Column(name = "ip", length = 45)
+    private String ip;
+
+    public boolean isActive() {
+        return revokedAt == null && LocalDateTime.now().isBefore(expiresAt);
+    }
+}

--- a/src/main/java/com/jobboard/jobportal/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/jobboard/jobportal/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.jobboard.jobportal.repository;
+
+import com.jobboard.jobportal.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByTokenHash(String tokenHash);
+}

--- a/src/main/java/com/jobboard/jobportal/scheduler/RefreshTokenCleanupJob.java
+++ b/src/main/java/com/jobboard/jobportal/scheduler/RefreshTokenCleanupJob.java
@@ -1,0 +1,4 @@
+package com.jobboard.jobportal.scheduler;
+
+public class RefreshTokenCleanupJob {
+}

--- a/src/main/java/com/jobboard/jobportal/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/jobboard/jobportal/security/JwtAuthenticationFilter.java
@@ -26,8 +26,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
-        // 로그인/재발급/로그아웃 등은 필터 스킵
-        return path.startsWith("/api/auth/");
+        String method = request.getMethod();
+        if (!"POST".equalsIgnoreCase(method)) return false;
+        return "/api/auth/login".equals(path)
+                || "/api/auth/logout".equals(path)
+                || "/api/auth/token/refresh".equals(path);
     }
 
     @Override

--- a/src/main/java/com/jobboard/jobportal/service/RefreshTokenService.java
+++ b/src/main/java/com/jobboard/jobportal/service/RefreshTokenService.java
@@ -1,4 +1,14 @@
 package com.jobboard.jobportal.service;
 
+import com.jobboard.jobportal.entity.User;
+
 public interface RefreshTokenService {
+    /** 로그인 성공 시 DB에 refresh 기록 저장 */
+    void saveLoginToken(User user, String rawRefresh, String userAgent, String ip);
+
+    /** 재발급(회전): 기존 refresh를 무효화하고 새 refresh 반환 */
+    String rotate(String rawRefresh, User user, String userAgent, String ip);
+
+    /** 로그아웃: refresh 무효화 */
+    void revoke(String rawRefresh);
 }

--- a/src/main/java/com/jobboard/jobportal/service/RefreshTokenService.java
+++ b/src/main/java/com/jobboard/jobportal/service/RefreshTokenService.java
@@ -1,0 +1,4 @@
+package com.jobboard.jobportal.service;
+
+public interface RefreshTokenService {
+}

--- a/src/main/java/com/jobboard/jobportal/service/impl/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/jobboard/jobportal/service/impl/RefreshTokenServiceImpl.java
@@ -1,4 +1,87 @@
 package com.jobboard.jobportal.service.impl;
 
-public class RefreshTokenServiceImpl {
+import com.jobboard.jobportal.entity.RefreshToken;
+import com.jobboard.jobportal.entity.User;
+import com.jobboard.jobportal.repository.RefreshTokenRepository;
+import com.jobboard.jobportal.security.JwtUtil;
+import com.jobboard.jobportal.service.RefreshTokenService;
+import com.jobboard.jobportal.util.HashUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RefreshTokenServiceImpl implements RefreshTokenService {
+
+    private final RefreshTokenRepository repo;
+    private final JwtUtil jwtUtil;
+
+    private static LocalDateTime toLdt(Date d) {
+        return LocalDateTime.ofInstant(d.toInstant(), ZoneId.systemDefault());
+    }
+
+    @Override
+    public void saveLoginToken(User user, String rawRefresh, String userAgent, String ip) {
+        Jws<Claims> jws = jwtUtil.parse(rawRefresh);
+        Claims c = jws.getBody();
+
+        RefreshToken rt = RefreshToken.builder()
+                .user(user)
+                .tokenHash(HashUtil.sha256Hex(rawRefresh))          // 원문 대신 해시 저장
+                .issuedAt(toLdt(c.getIssuedAt()))
+                .expiresAt(toLdt(c.getExpiration()))
+                .userAgent(userAgent)
+                .ip(ip)
+                .build();
+        repo.save(rt);
+    }
+
+    @Override
+    public String rotate(String rawRefresh, User user, String userAgent, String ip) {
+        // 1) 파싱/검증
+        Jws<Claims> jws = jwtUtil.parse(rawRefresh);
+        Claims c = jws.getBody();
+        if (!"refresh".equals(c.get("type"))) throw new JwtException("not refresh");
+
+        // 2) 저장소에서 활성 레코드 확인
+        String oldHash = HashUtil.sha256Hex(rawRefresh);
+        RefreshToken old = repo.findByTokenHash(oldHash)
+                .orElseThrow(() -> new JwtException("unknown refresh"));
+        if (!old.isActive()) throw new JwtException("revoked or expired");
+
+        // 3) 새 refresh 발급/저장
+        String newRefresh = jwtUtil.generateRefresh(user.getEmail());
+        Jws<Claims> newJws = jwtUtil.parse(newRefresh);
+
+        RefreshToken next = RefreshToken.builder()
+                .user(user)
+                .tokenHash(HashUtil.sha256Hex(newRefresh))
+                .issuedAt(toLdt(newJws.getBody().getIssuedAt()))
+                .expiresAt(toLdt(newJws.getBody().getExpiration()))
+                .userAgent(userAgent)
+                .ip(ip)
+                .build();
+        repo.save(next);
+
+        // 4) 이전 토큰 무효화(회전)
+        old.setRevokedAt(LocalDateTime.now());
+        old.setReplacedBy(next);
+
+        return newRefresh;
+    }
+
+    @Override
+    public void revoke(String rawRefresh) {
+        String h = HashUtil.sha256Hex(rawRefresh);
+        repo.findByTokenHash(h).ifPresent(rt -> rt.setRevokedAt(LocalDateTime.now()));
+    }
 }

--- a/src/main/java/com/jobboard/jobportal/service/impl/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/jobboard/jobportal/service/impl/RefreshTokenServiceImpl.java
@@ -1,0 +1,4 @@
+package com.jobboard.jobportal.service.impl;
+
+public class RefreshTokenServiceImpl {
+}

--- a/src/main/java/com/jobboard/jobportal/util/HashUtil.java
+++ b/src/main/java/com/jobboard/jobportal/util/HashUtil.java
@@ -1,4 +1,19 @@
 package com.jobboard.jobportal.util;
 
-public class HashUtil {
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+public final class HashUtil {
+    private HashUtil() {}
+    public static String sha256Hex(String value) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] d = md.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(d.length * 2);
+            for (byte b : d) sb.append(String.format("%02x", b));
+            return sb.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
 }

--- a/src/main/java/com/jobboard/jobportal/util/HashUtil.java
+++ b/src/main/java/com/jobboard/jobportal/util/HashUtil.java
@@ -1,0 +1,4 @@
+package com.jobboard.jobportal.util;
+
+public class HashUtil {
+}

--- a/src/main/resources/db/migration/V2_refresh_tokens.sql
+++ b/src/main/resources/db/migration/V2_refresh_tokens.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+                                              id            BIGINT PRIMARY KEY AUTO_INCREMENT,
+                                              user_id       BIGINT      NOT NULL,
+                                              token_hash    CHAR(64)    NOT NULL UNIQUE, -- SHA-256 hex
+    issued_at     DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at    DATETIME    NOT NULL,
+    revoked_at    DATETIME         NULL,
+    replaced_by_id BIGINT          NULL,
+    user_agent    VARCHAR(255)     NULL,
+    ip            VARCHAR(45)      NULL,
+    CONSTRAINT fk_rt_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    INDEX idx_rt_user (user_id),
+    INDEX idx_rt_expires (expires_at)
+    );


### PR DESCRIPTION
- 로그인 시 refresh 해시(DB) 저장, 재발급 시 회전(이전 토큰 무효화)
- 재발급 성공 시 Authorization 헤더로 새 Access, 쿠키는 새 refresh로 교체
- 로그아웃 시 DB 무효화 + 삭제 쿠키
- 보안 응답 일관화: 미인증 401 / 권한부족 403

테스트
- requests.http 기준 6단계: 200/200/204(or 200)/200/204/401
